### PR TITLE
Predefined particle masses when MassTable is empty

### DIFF
--- a/src/io/io_gadget4.c
+++ b/src/io/io_gadget4.c
@@ -217,12 +217,15 @@ void load_particles_gadget4(char *filename, struct particle **p, int64_t *num_p)
     H5Gclose(HDF_Header);
     H5Gclose(HDF_Parameters);
 
-    PARTICLE_MASS        = massTable[GADGET4_DM_PARTTYPE] * GADGET4_MASS_CONVERSION;
-    AVG_PARTICLE_SPACING = cbrt(PARTICLE_MASS / (Om * CRITICAL_DENSITY));
+    if (!PARTICLE_MASS) {
+      PARTICLE_MASS = massTable[GADGET4_DM_PARTTYPE] * GADGET4_MASS_CONVERSION;
 
-    if (RESCALE_PARTICLE_MASS)
-        PARTICLE_MASS =
-            Om * CRITICAL_DENSITY * pow(BOX_SIZE, 3) / TOTAL_PARTICLES;
+      if (RESCALE_PARTICLE_MASS)
+          PARTICLE_MASS =
+              Om * CRITICAL_DENSITY * pow(BOX_SIZE, 3) / TOTAL_PARTICLES;
+    }
+
+    AVG_PARTICLE_SPACING = cbrt(PARTICLE_MASS / (Om * CRITICAL_DENSITY));
 
     printf("GADGET4: filename:       %s\n", filename);
     printf("GADGET4: box size:       %g Mpc/h\n", BOX_SIZE);


### PR DESCRIPTION
I added the ability to define the PARTICLE_MASS in Gadget-4 runs. I also fix the bug from original Rockstar where the average particle spacing is incorrect when rescaling the particle masses, since it is called before the rescaling process. 