### PR TITLE
Append .hdf5 suffix to GADGET-4 snapshot filename if ENABLE_HDF5

### DIFF
--- a/src/io/meta_io.c
+++ b/src/io/meta_io.c
@@ -149,6 +149,7 @@ void read_particles(char *filename) {
         load_particles(filename, &p, &num_p);
     else if (!strncasecmp(FILE_FORMAT, "GADGET4", 7)) {
 #ifdef ENABLE_HDF5
+		strstr(filename, ".hdf5") || strcat(filename, ".hdf5");
         load_particles_gadget4(filename, &p, &num_p);
         gadget = 1;
 #else


### PR DESCRIPTION
The current HDF5 interface for GADGET-4 input does not append the ".hdf5" suffix to the `filename` argument. Therefore, when `load_particles_gadget4()` calls the HDF5 functions to open the input snapshots, they cannot find the file and instead throw an error, e.g.,
```
[Error] Failed to open HDF5 file
/raven/ptmp/minh/GADGET/fnl0_L1000_N2048/s01/snapdir_000/snapshot_000.26
```
One can see from the error that the `filename` argument appears to be missing the ".hdf5" suffix in the end.

This can be simply fixed by introducing a one-liner that checks and appends ".hdf5" to `filename`, before calling `load_particles_gadget4()` inside [src/io/meta_io.c](https://github.com/Tomoaki-Ishiyama/mpi-rockstar/compare/main...MinhMPA:mpi-rockstar:Fix_gadget4hdf5_interface?expand=1#diff-4c9bfd1c508bf929f9b22cc7067fb0b359c24f9d3da967de2e6ec265277e86bf), as shown below.