### PR TITLE
Ensure PARTICLE_MASS derived from massTable in header

### DIFF
--- a/src/io/io_gadget4.c
+++ b/src/io/io_gadget4.c
@@ -217,10 +217,9 @@ void load_particles_gadget4(char *filename, struct particle **p, int64_t *num_p)
     H5Gclose(HDF_Header);
     H5Gclose(HDF_Parameters);
 
-    if (!PARTICLE_MASS) {
-      PARTICLE_MASS = massTable[GADGET4_DM_PARTTYPE] * GADGET4_MASS_CONVERSION;
+	PARTICLE_MASS = massTable[GADGET4_DM_PARTTYPE] * GADGET4_MASS_CONVERSION;
 
-      if (RESCALE_PARTICLE_MASS)
+      if (RESCALE_PARTICLE_MASS) {
           PARTICLE_MASS =
               Om * CRITICAL_DENSITY * pow(BOX_SIZE, 3) / TOTAL_PARTICLES;
     }


### PR DESCRIPTION
Currently, for the GADGET-4 IO interface at `src/io/io_gadget4.c`, `PARTICLE_MASS` is only derived from the `massTable` in `HDF_Header` if not previously set elsewhere. Since `PARTICLE_MASS` is always computed at initialization by `setup_config()` in `src/config.c`, if the users forgot to set, in their `.cfg` file, either `PARTICLE_MASS` directly or `BOX_SIZE` and `Om`, `PARTICLE_MASS` would be computed from the default values in `src/config.template.h`, instead of from `HDF_Header` (as the users would likely assume here).

Since this behavior is not currently documented somewhere, I figure it would be helpful to enforce `PARTICLE_MASS` to be always derived from `HDF_Header`.