### PR TITLE
PARTICLE_MASS prioritises the mass in MassTable in Gadget-4 and AREPO

### DIFF
--- a/src/io/io_arepo.c
+++ b/src/io/io_arepo.c
@@ -141,12 +141,17 @@ void load_particles_arepo(char *filename, struct particle **p, int64_t *num_p) {
 
     H5Gclose(HDF_Header);
 
-    PARTICLE_MASS        = massTable[AREPO_DM_PARTTYPE] * AREPO_MASS_CONVERSION;
-    AVG_PARTICLE_SPACING = cbrt(PARTICLE_MASS / (Om * CRITICAL_DENSITY));
+    if (massTable[AREPO_DM_PARTTYPE] || !PARTICLE_MASS ||
+        RESCALE_PARTICLE_MASS) {
+        if (!RESCALE_PARTICLE_MASS)
+            PARTICLE_MASS =
+                massTable[AREPO_DM_PARTTYPE] * AREPO_MASS_CONVERSION;
+        else
+            PARTICLE_MASS =
+                Om * CRITICAL_DENSITY * pow(BOX_SIZE, 3) / TOTAL_PARTICLES;
+    }
 
-    if (RESCALE_PARTICLE_MASS)
-        PARTICLE_MASS =
-            Om * CRITICAL_DENSITY * pow(BOX_SIZE, 3) / TOTAL_PARTICLES;
+    AVG_PARTICLE_SPACING = cbrt(PARTICLE_MASS / (Om * CRITICAL_DENSITY));
 
     printf("AREPO: filename:       %s\n", filename);
     printf("AREPO: box size:       %g Mpc/h\n", BOX_SIZE);

--- a/src/io/io_gadget4.c
+++ b/src/io/io_gadget4.c
@@ -217,12 +217,14 @@ void load_particles_gadget4(char *filename, struct particle **p, int64_t *num_p)
     H5Gclose(HDF_Header);
     H5Gclose(HDF_Parameters);
 
-    if (!PARTICLE_MASS) {
-      PARTICLE_MASS = massTable[GADGET4_DM_PARTTYPE] * GADGET4_MASS_CONVERSION;
-
-      if (RESCALE_PARTICLE_MASS)
-          PARTICLE_MASS =
-              Om * CRITICAL_DENSITY * pow(BOX_SIZE, 3) / TOTAL_PARTICLES;
+    if (massTable[GADGET4_DM_PARTTYPE] || !PARTICLE_MASS ||
+        RESCALE_PARTICLE_MASS) {
+        if (!RESCALE_PARTICLE_MASS)
+            PARTICLE_MASS =
+                massTable[GADGET4_DM_PARTTYPE] * GADGET4_MASS_CONVERSION;
+        else
+            PARTICLE_MASS =
+                Om * CRITICAL_DENSITY * pow(BOX_SIZE, 3) / TOTAL_PARTICLES;
     }
 
     AVG_PARTICLE_SPACING = cbrt(PARTICLE_MASS / (Om * CRITICAL_DENSITY));


### PR DESCRIPTION
This PR solves the mass assignment issue raised in PR[#22](https://github.com/Tomoaki-Ishiyama/mpi-rockstar/pull/22).
`PARTICLE_MASS` is always set in initialisation, and the mass in `MassTable` for Gadget-4 format is ignored.
The modules to load Gadget-4 and AREPO snapshots are modified so that the mass in `MassTable` is prioritised if it is not empty, which is consistent with the original Gadget2 binary format.